### PR TITLE
1.修复自定义请求头填写Cookie时被覆盖问题 2.支持填写多个自定义请求头

### DIFF
--- a/src/main/java/com/summersec/attack/UI/MainController.java
+++ b/src/main/java/com/summersec/attack/UI/MainController.java
@@ -216,9 +216,16 @@ public class MainController {
         //自定义请求头
         Map<String, String> myheader= new HashMap<>() ;
         if(!this.globalHeader.getText().equals("")) {
-            String header[] = this.globalHeader.getText().split(":",2);
+            String headers[] = this.globalHeader.getText().split("&&&");
 //        myheader(this.globalHeader.getText() -> this.globalHeader.getText().split(":"))
-            myheader.put(header[0], header[1]);
+            for (int i = 0; i < headers.length; i++ ) {
+                String header[] = headers[i].split(":", 2);
+                if (header[0].toLowerCase().equals("cookie")) {
+                    myheader.put("Cookie", header[1]);
+                } else {
+                    myheader.put(header[0], header[1]);
+                }
+            }
         }
 //        this.globalHeader = myheader
         String postData = (String)this.post_data.getText();

--- a/src/main/java/com/summersec/attack/core/AttackService.java
+++ b/src/main/java/com/summersec/attack/core/AttackService.java
@@ -21,11 +21,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.Proxy;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -63,13 +59,20 @@ public class AttackService {
 
     public HashMap<String, String> getCombineHeaders(HashMap<String, String> header) {
         HashMap<String, String> combineHeaders = new HashMap();
-        if (globalHeader != null) {
-            combineHeaders.putAll(header);
-            combineHeaders.putAll(globalHeader);
+        Set<String> keySet = globalHeader.keySet();
+        if (keySet.size() != 0) {
+            for (String key : keySet) {
+                if (key.equals("Cookie")) {
+                    header.replace("Cookie", globalHeader.get(key) + "; " + header.get(key));
+                    combineHeaders.putAll(header);
+                } else {
+                    combineHeaders.putAll(header);
+                    combineHeaders.put(key, globalHeader.get(key));
+                }
+            }
         } else {
             combineHeaders = header;
         }
-
         return combineHeaders;
     }
 


### PR DESCRIPTION
1.修复自定义请求头填写Cookie时被覆盖问题
2.支持填写多个自定义请求头，使用&&&分割，如abc:123&&&test:123 https://github.com/SummerSec/ShiroAttack2/issues/33